### PR TITLE
Hide header text on mobile

### DIFF
--- a/apps/web/components/layout.tsx
+++ b/apps/web/components/layout.tsx
@@ -49,7 +49,7 @@ export default function Layout({ children }: LayoutProps) {
           {!isAuthRequired || (!!databases?.length && databases.length > 0) ? (
             <Header />
           ) : (
-            <div className="fixed top-8 left-8 w-[419px] max-w-full flex justify-between z-20">
+            <div className="fixed top-8 left-8 w-[419px] max-w-full hidden lg:flex justify-between z-20">
               <span className="text-sm text-muted-foreground font-mono">database.build</span>
               <Link
                 href="https://supabase.com"


### PR DESCRIPTION
Hides unauthenticated header text on mobile.

### Before
![image](https://github.com/user-attachments/assets/3d18ac12-3894-4266-a217-c498daae0afe)

### After
![image](https://github.com/user-attachments/assets/4a4b581d-870b-4cf1-801b-79a1311db9d4)
