### PR TITLE
Fix service worker unavailable after hard reload

### DIFF
--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -11,7 +11,14 @@ const queryClient = new QueryClient()
 
 async function registerServiceWorker() {
   try {
-    await navigator.serviceWorker.register('/sw.mjs')
+    const reg = await navigator.serviceWorker.getRegistration()
+
+    // If this was a hard refresh (no controller), browsers will disable service workers
+    // We should soft reload the page to ensure the service worker is active
+    if (reg?.active && !navigator.serviceWorker.controller) {
+      window.location.reload()
+    }
+    await navigator.serviceWorker.register('/sw.mjs', { scope: '/' })
   } catch (error) {
     console.error('Failed to register service worker', error)
   }


### PR DESCRIPTION
Turns out that service workers are disabled after a [hard reload](https://w3c.github.io/ServiceWorker/#navigator-service-worker-controller) (cmd+shift+r). This PR will detect this and perform a soft reload to re-enable them.