### PR TITLE
Adds permanent redirect from legacy domain

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -60,7 +60,7 @@ const nextConfig = {
           },
         ],
         destination: `${process.env.NEXT_PUBLIC_CURRENT_DOMAIN}/:path?from=${legacyHostname}`,
-        permanent: false,
+        permanent: true,
       })
     }
 


### PR DESCRIPTION
Switches redirect from postgres.new to database.build to be permanent so the browsers will cache it.